### PR TITLE
Add hostap project

### DIFF
--- a/config.sample.ini
+++ b/config.sample.ini
@@ -14,7 +14,7 @@ LogFile = /home/user/troll/logs/err.log
 
 # A comma-delimited list of projects to consider for review. These should be
 # specified as new sections with 'project_<name>' below
-Projects = flashrom,kernel
+Projects = flashrom,kernel,linux-firmware,hostap
 
 
 # Project-specific values which specify how patches will be reviewed. These
@@ -140,3 +140,13 @@ GerritRemoteName = cros
 Prefixes = UPSTREAM,BACKPORT,FROMGIT,FROMLIST
 ApprovedPatchworks = lore,freedesktop,kernel,linuxtv,ozlabs
 BlacklistedRepos = linuxnext,drmtip,drmtip_github
+
+[project_hostap]
+Name = hostap
+GerritProject = chromiumos/third_party/hostap
+MainlineLocation = git://w1.fi/srv/git/hostap.git
+MainlineBranch = master
+LocalLocation = /home/user/troll/repos/hostap/
+GerritRemoteName = cros
+Prefixes = UPSTREAM,BACKPORT,FROMGIT,FROMLIST
+ApprovedPatchworks = ozlabs


### PR DESCRIPTION
Also fixup the Projects list for linux-firmware.

hostap = wpa_supplicant and hostapd.

---

Totally untested, of course ;)

By the way, is there anyway to blacklist certain cros branches? For instance, other teams are using the wpa_supplicant-2.7 branch, and they aren't really following CrOS practices; probably best not to bug them.