### PR TITLE
troll: Increase diff indentation to 4 spaces

### DIFF
--- a/trollreviewer.py
+++ b/trollreviewer.py
@@ -37,8 +37,9 @@ class ChangeReviewer(object):
     # Leave room for boilerplate and other review feedback, 4k chars for now
     max_size = self.msg_limit - 4096
     msg = ''
+    # Indent with 4 spaces to ensure diff is code formatted, per markdown spec.
     for l in self.diff:
-      msg += '  {}\n'.format(l)
+      msg += '    {}\n'.format(l)
 
     if len(msg) > max_size:
       trunc_msg = '\n\n  !!!! Diff truncated !!!!'


### PR DESCRIPTION
Gerrit previously supported a subset of markdown features and accepted lines prefixed with two spaces as monospaced formatting.

Recently Gerrit has added more robust support for markdown more in line with the spec, which defines 4 leading spaces for monospaced formatting: https://commonmark.org/help/

Increase the leading spaces for the diff output to ensure it is formatted correctly on Gerrit.

Signed-off-by: Drew Davenport <ddavenport@chromium.org>