### PR TITLE
troll: Escape diff and fixes comments

### DIFF
--- a/trollreviewer.py
+++ b/trollreviewer.py
@@ -38,14 +38,16 @@ class ChangeReviewer(object):
     max_size = self.msg_limit - 4096
     msg = ''
     for l in self.diff:
-      msg += '  {}\n'.format(l)
+      msg += '{}\n'.format(l)
 
     if len(msg) > max_size:
-      trunc_msg = '\n\n  !!!! Diff truncated !!!!'
+      trunc_msg = '\n\n!!!! Diff truncated !!!!'
       msg = msg[:(max_size - len(trunc_msg))]
       msg += trunc_msg
 
-    return msg
+    # Surround the diff block in triple-backtips to ensure that it gets monospace font
+    # and not formatted as markdown.
+    return '```\n' + msg + '\n```'
 
   def add_successful_review(self):
     msg = self.strings.SUCCESS.format(random.choice(self.strings.SWAG))

--- a/trollreviewergit.py
+++ b/trollreviewergit.py
@@ -98,6 +98,8 @@ class GitChangeReviewer(ChangeReviewer):
     for l in fixes_ref.splitlines():
       msg += self.strings.FIXES_REF_LINE.format(l)
     msg += self.strings.FIXES_REF_FOOTER
+    # Escape the message in triple-ticks to ensure correct markdown formatting.
+    msg = '```\n' + msg + '\n```'
     self.review_result.add_review(ReviewType.FIXES_REF, msg, notify=True,
                                   ignore_positive_votes=True)
 

--- a/trollstrings.py
+++ b/trollstrings.py
@@ -109,14 +109,14 @@ This is expected, and this message is posted to make reviewing backports easier.
 
 '''
   FOUND_FIXES_REF_HEADER='''
- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
- !! NOTE: This patch has been referenced in the Fixes: tag of another commit. As
- !!       such, manual review of this patch is required. If you haven't already,
- !!       consider backporting the following patch[es]:'''
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!! NOTE: This patch has been referenced in the Fixes: tag of another commit. As
+!!       such, manual review of this patch is required. If you haven't already,
+!!       consider backporting the following patch[es]:'''
   FIXES_REF_LINE='''
- !!  {}'''
+!!  {}'''
   FIXES_REF_FOOTER='''
- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 '''
   FOOTER='''
 To learn more about backporting patches to Chromium OS, check out:


### PR DESCRIPTION
Gerrit recently released support for markdown in comments, which ended up regressing the formatting of monospace comments.

Previously Gerrit would format lines with two leading spaces as monospace/code. With the update, four leading spaces or escaping the block with triple-backticks is required.

Signed-off-by: Drew Davenport <ddavenport@chromium.org>